### PR TITLE
Update to Node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
     default: 1.2.0
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
GitHub Actions warns:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: `algolia/setup-algolia-cli@0af6968e098cc0526e22871fe46abe9a34e43e8d`. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.